### PR TITLE
Render map panel current messages on top of allframes messages (#5325)

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -525,6 +525,9 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
       topicLayer.allFrames.addLayer(pointLayer);
 
+      // Push this layer to the back so it renders under the current messages.
+      pointLayer.bringToBack();
+
       allGeoMessages
         .filter((message) => message.topic === topic)
         .forEach((message) => addGeoJsonMessage(message, topicLayer.allFrames));


### PR DESCRIPTION
The map layers for allFrames messages and current messages are added in two separate hooks so the order of insertion depends on which order react executes the two `useEffect` hooks.

This changes the allFrames effect hook to always push the current messages layer to the back of the layer group so that current messages are rendered on top of it.

**User-Facing Changes**


**Description**


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
